### PR TITLE
Support passing in of RegExps for regex property

### DIFF
--- a/replace.js
+++ b/replace.js
@@ -21,7 +21,13 @@ module.exports = function(opts) {
     if (options.multiline) {
         flags += "m";
     }
-    regex = new RegExp(options.regex, flags);
+
+    if (options.regex instanceof RegExp) {
+        regex = options.regex;
+    }
+    else {
+        regex = new RegExp(options.regex, flags);
+    }
     canReplace = !options.preview && options.replacement !== undefined;
 
     if (options.include) {


### PR DESCRIPTION
Pretty straightforward change. In the current implementation of replace, an error will be thrown error if you pass in a RegExp as the value of `regex`. This isn't a big deal if you're using replace from the command line, but it's kind of annoying if you're using it through the programmatic interface.
