### PR TITLE
Fixes issue with `undefined` being outputed (related to `fileColor`)

### DIFF
--- a/replace.js
+++ b/replace.js
@@ -139,7 +139,7 @@ module.exports = function(options) {
         }
 
         if (!options.silent) {
-            var printout = file[options.fileColor];
+            var printout = file[options.fileColor] || file;
             if (options.count) {
                 printout += (" (" + match.length + ")").grey;
             }


### PR DESCRIPTION
Fixes an issue where `undefined` is printed to the console for each match instead of it's name when `fileColor` is not passed as an option when `replace` is called pragmatically.
