### PR TITLE
Allow directory scanning without recursion flag.

### DIFF
--- a/replace.js
+++ b/replace.js
@@ -65,7 +65,7 @@ module.exports = function(options) {
       return ((!includes || !isFile || inIncludes) && (!excludes || !inExcludes));
     }
 
-    function replacizeFile(file) {
+    function replacizeFile(file, depth) {
       fs.lstat(file, function(err, stats) {
           if (err) throw err;
 
@@ -95,18 +95,18 @@ module.exports = function(options) {
                   }
               });
           }
-          else if (stats.isDirectory() && options.recursive) {
+          else if (stats.isDirectory() && (options.recursive || depth == undefined || depth == 0)) {
               fs.readdir(file, function(err, files) {
                   if (err) throw err;
                   for (var i = 0; i < files.length; i++) {
-                      replacizeFile(path.join(file, files[i]));
+                      replacizeFile(path.join(file, files[i]), depth++);
                   }
               });
           }
        });
     }
 
-    function replacizeFileSync(file) {
+    function replacizeFileSync(file, depth) {
       var stats = fs.lstatSync(file);
       if (stats.isSymbolicLink()) {
           // don't follow symbolic links for now
@@ -124,10 +124,10 @@ module.exports = function(options) {
               fs.writeFileSync(file, text);
           }
       }
-      else if (stats.isDirectory() && options.recursive) {
+      else if (stats.isDirectory() && (options.recursive || depth == undefined || depth == 0)) {
           var files = fs.readdirSync(file);
           for (var i = 0; i < files.length; i++) {
-              replacizeFileSync(path.join(file, files[i]));
+              replacizeFileSync(path.join(file, files[i]), depth++);
           }
       }
     }


### PR DESCRIPTION
The replace package will not scan files in any directory unless the
recursion option is set.  This has unintended consequences if only
files in one directory should be affected.  This patch allows
scanning the initial path parameter if it is a directory and keeps
track of the recurse depth with an extra parameter.
